### PR TITLE
Handle empty leaderboard / reset leaderboard changes

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -53,11 +53,11 @@ client.on('messageReactionAdd', async (reaction, user) => {
 
         if (foundUser) {
             foundUser.increment('points', { by: 5 });
-            reaction.message.channel.send(`Congrats ${foundUser.username}, you just earned 5 points! (Total points: ${foundUser.points + 5})`);
+            reaction.message.channel.send(`Congrats <@${reaction.message.author.id}>, <@${user.id}> just awarded you 5 points! (Total points: ${foundUser.points + 5})`);
         }
         else {
             const newUser = await Users.create({ username: reaction.message.author.username });
-            reaction.message.channel.send(`Congrats ${newUser.username}, you just earned 5 points! (Total points: ${newUser.points})`);
+            reaction.message.channel.send(`Congrats <@${reaction.message.author.id}>,  <@${user.id}> just awarded you 5 points! (Total points: ${newUser.points})`);
         }
     }
 });

--- a/tasks/tasks.js
+++ b/tasks/tasks.js
@@ -1,3 +1,5 @@
+const sequelize = require('../utilities/db');
+
 const { MessageEmbed } = require('discord.js'),
     CronJob = require('cron').CronJob,
     { targetChannel } = require('../config.json'),
@@ -6,37 +8,44 @@ const { MessageEmbed } = require('discord.js'),
 
 /*
 Cron job format =  '* * * * * *'
-Sec(0-59), min(0-59), hour(0-23), day of month(1-31), month(1-12), day of week(0-6 starting with sunday)
+Sec(0-59), min(0-59), hour(0-23), day of month(1-31), month(0-11), day of week(0-6 starting with sunday)
 */
 
+// 1 11 * * 1
 const weeklyLeaderboardResults = (client) => new CronJob('1 11 * * 1', async function() {
-    try {
-        const chartUrl = await getLeaderboardGraph();
+    const count = await sequelize.query('SELECT COUNT(*) FROM Users;');
+    if (count[0][0]['COUNT(*)'] > 0) {
+        try {
+            const chartUrl = await getLeaderboardGraph();
 
-        const users = await Users.findAll({ limit: 5, order: [['points', 'DESC']] });
-        const emojiSquare = ':white_small_square: ';
+            const users = await Users.findAll({ limit: 5, order: [['points', 'DESC']] });
+            const emojiSquare = ':white_small_square: ';
 
-        let description = '';
+            let description = '';
 
-        for (const user of users) {
-            description += emojiSquare + user.dataValues.username + '\n';
+            for (const user of users) {
+                description += emojiSquare + user.dataValues.username + '\n';
+            }
+
+            const leaderboardResults = new MessageEmbed().setColor('#0080ff').setTitle('Weekly Leaderboard Results').setDescription(`Congratulations to the top ${users.length} contributors!\n\n${description}`).setImage(chartUrl);
+
+            client.channels.cache.get(targetChannel,
+            ).send({ embeds: [leaderboardResults] });
         }
-
-        const leaderboardResults = new MessageEmbed().setColor('#0080ff').setTitle('Weekly Leaderboard Results').setDescription(`Congratulations to the top ${users.length} contributors!\n\n${description}`).setImage(chartUrl);
-
-        client.channels.cache.get(targetChannel,
-        ).send({ embeds: [leaderboardResults] });
+        catch (error) {
+            console.error(error);
+        }
     }
-    catch (error) {
-        console.error(error);
+    else {
+        client.channels.cache.get(targetChannel).send('Want to help your club? We are looking for new top contributors. Start by using the <:award:905616817102413825> emoji today!');
     }
 });
 
+// 0 11 20 4,11 *
 const resetLeaderboard = (client) => new CronJob('0 11 20 4,11 *', async function() {
     try {
-        Users.destroy({ truncate : true });
-        client.channels.cache.get(targetChannel,
-        ).send('Leaderboard reset.');
+        await sequelize.query('DELETE FROM Users;');
+        client.channels.cache.get(targetChannel).send('Leaderboard reset.');
     }
     catch (error) {
         console.error(error);

--- a/tasks/tasks.js
+++ b/tasks/tasks.js
@@ -1,10 +1,9 @@
-const sequelize = require('../utilities/db');
-
 const { MessageEmbed } = require('discord.js'),
     CronJob = require('cron').CronJob,
     { targetChannel } = require('../config.json'),
     Users = require('../models/users.js'),
-    getLeaderboardGraph = require('../utilities/getLeaderboardGraph.js');
+    getLeaderboardGraph = require('../utilities/getLeaderboardGraph.js'),
+    sequelize = require('../utilities/db');
 
 /*
 Cron job format =  '* * * * * *'


### PR DESCRIPTION
Updated resetLeaderboard to use a raw query.

Added a check to weeklyLeaderboardResults that will look at the Users table and if empty, will not send the results to the server.

Added user specific tags to award reaction confirmation message.